### PR TITLE
Issue Fix - Textbox and MC movement

### DIFF
--- a/TimeCubeousGame.gmx/objects/obj_neku.object.gmx
+++ b/TimeCubeousGame.gmx/objects/obj_neku.object.gmx
@@ -69,34 +69,39 @@ var left_key = keyboard_check(vk_left);
 var up_key = keyboard_check(vk_up);
 var down_key = keyboard_check(vk_down);
 
-// Move right
-if(right_key) {
-    phy_position_x += spd;
-    sprite_index = spr_neku_right;
-    image_speed = img_spd;
-}
-
-// Move left
-if(left_key) {
-    phy_position_x -= spd;
-    sprite_index = spr_neku_left;
-    image_speed = img_spd;
-}
-
-// Move up
-if(up_key) {
-    phy_position_y -= spd; // note that the -y direction is up.
-    sprite_index = spr_neku_up;
-    image_speed = img_spd;
-    //image_speed = .2;
-}
-
-// Move down
-if(down_key) {
-    phy_position_y += spd;
-    sprite_index = spr_neku_down;
-    image_speed = img_spd;
-    //image_speed = .2;
+//verify if textbox is on or off
+//if it's on you don't  move
+if (!global.textbox_ON)
+    {
+    // Move right
+    if(right_key) {
+        phy_position_x += spd;
+        sprite_index = spr_neku_right;
+        image_speed = img_spd;
+    }
+    
+    // Move left
+    if(left_key) {
+        phy_position_x -= spd;
+        sprite_index = spr_neku_left;
+        image_speed = img_spd;
+    }
+    
+    // Move up
+    if(up_key) {
+        phy_position_y -= spd; // note that the -y direction is up.
+        sprite_index = spr_neku_up;
+        image_speed = img_spd;
+        //image_speed = .2;
+    }
+    
+    // Move down
+    if(down_key) {
+        phy_position_y += spd;
+        sprite_index = spr_neku_down;
+        image_speed = img_spd;
+        //image_speed = .2;
+    }
 }
 
 // Stop animation depending on the current frame

--- a/TimeCubeousGame.gmx/objects/obj_startMenu.object.gmx
+++ b/TimeCubeousGame.gmx/objects/obj_startMenu.object.gmx
@@ -42,7 +42,6 @@ cursorPos = 0; // move[cursorPos] returns the item the cursor is pointing to.
    // the actual cursor should be pointing to "Start Game" in the menu. 
 
 
-
 </string>
           </argument>
         </arguments>
@@ -103,6 +102,35 @@ var select;
 select = max(keyboard_check_released(vk_enter), keyboard_check_released(vk_shift), keyboard_check_released(ord("Z")), 0);
 
 if (select == 1) { scr_startMenu(); }
+</string>
+          </argument>
+        </arguments>
+      </action>
+    </event>
+    <event eventtype="7" enumb="2">
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>//on game start
+
+//this boolean will be our textbox checker to freeze other game processes while it's on
+//if it's off, nothing happens.
+globalvar textbox_ON;
+
+textbox_ON = false;
 </string>
           </argument>
         </arguments>

--- a/TimeCubeousGame.gmx/objects/obj_textbox.object.gmx
+++ b/TimeCubeousGame.gmx/objects/obj_textbox.object.gmx
@@ -76,6 +76,9 @@ start_pointer=0; //this is the pointer for the text loader to know where to star
             <string>//cleans data
 ds_queue_destroy(cmd_data_queue);
 ds_queue_destroy(cmd_pos_queue);
+
+//text box variable off
+global.textbox_ON = false;
 </string>
           </argument>
         </arguments>
@@ -699,6 +702,9 @@ surface_reset_target();
           <argument>
             <kind>1</kind>
             <string>var i, i2;
+
+//turn global textbox variable on
+global.textbox_ON = true;
 
 if (current_text&gt;-1) //checks if the alarm "create event" has been completed
 {


### PR DESCRIPTION
MC no longer moves while textbox is displayed. A global variable called
textbox_ON is used to control this. Called on any object script or
script, it's called as global.textbox_ON.
